### PR TITLE
Use r_process$cleanup() instead of r_process$finalize()

### DIFF
--- a/R/CallrFutureBackend-class.R
+++ b/R/CallrFutureBackend-class.R
@@ -464,7 +464,11 @@ await <- function(future, ...) {
       
       ## Finalize the 'callr' process, which includes remove any temporary
       ## files that it created
-      process$finalize()
+      if (is.function(process$cleanup)) {
+        process$cleanup()
+      } else {
+        process$finalize()
+      }
     }
 
     ## Failed to launch?
@@ -538,8 +542,12 @@ await <- function(future, ...) {
 
   ## Finalize the 'callr' process, which includes remove any temporary
   ## files that it created
-  process$finalize()
-  
+  if (is.function(process$cleanup)) {
+    process$cleanup()
+  } else {
+    process$finalize()
+  }
+
   result
 } # await()
 


### PR DESCRIPTION
Future callr will move r_process$finalize() to private (as required by newer R6) and adds a public cleanup() method for explicit resource cleanup.

Fall back to finalize() for compatibility with older callr versions.